### PR TITLE
Add requirements.txt to ease installation of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+pillow
+pygubu


### PR DESCRIPTION
Dependencies can now easily be installed using `pip install -r requirements.txt` after cloning the repo.